### PR TITLE
#53 [Feat] 글 상세 페이지, 예약 완료 페이지 지도 컴포넌트 연동하여 주소에 해당하는 위치 띄우기

### DIFF
--- a/src/pages/detail/DetailPage.jsx
+++ b/src/pages/detail/DetailPage.jsx
@@ -13,6 +13,7 @@ import profileSmallIcon from '../../assets/svg/profileSmall.svg';
 import likeNullIcon from '../../assets/svg/likeNull.svg';
 import likeFullIcon from '../../assets/svg/likefull.svg';
 import chattingIcon from '../../assets/svg/chatting.svg';
+import Map from '../../components/common/map/Map';
 
 function DetailPage() {
   const { postId } = useParams();
@@ -165,7 +166,7 @@ function DetailPage() {
             {amenities}
           </pre>
           <h3 className={styles.subTitle}>오시는 길</h3>
-          <div className={styles.map}>지도 영역</div>
+          <Map location={location} />
         </div>
       </div>
     </div>

--- a/src/pages/reservation/ReservationSuccessPage.jsx
+++ b/src/pages/reservation/ReservationSuccessPage.jsx
@@ -8,6 +8,7 @@ import { ko } from 'date-fns/locale';
 import styles from './reservation.module.scss';
 import calendarIcon from '../../assets/svg/calendar.svg';
 import locationIcon from '../../assets/svg/location.svg';
+import Map from '../../components/common/map/Map';
 
 function ReservationSuccessPage() {
   const navigate = useNavigate();
@@ -46,7 +47,7 @@ function ReservationSuccessPage() {
       </div>
       <div className={styles.resSuccessMapBox}>
         <h2 className={styles.resSuccessTitle}>{data.data.title}</h2>
-        <div className={styles.resSuccessMap}>지도 영역</div>
+        <Map location={data.data.location} />
       </div>
       <div className={styles.resSuccessInfoWrap}>
         <div className={styles.resSuccessInfoBox}>


### PR DESCRIPTION
https://github.com/ShareOffice-11/FE/issues/53 [[Feat] 글 상세 페이지, 예약 완료 페이지 지도 컴포넌트 연동하여 주소에 해당하는 위치 띄우기](https://github.com/ShareOffice-11/FE/commit/311546f4f2efef76897dc9723884712b3cd5cdd3)