### PR TITLE
#198 #199 [[Refactor] 무한스크롤 - 성능 개선(캐싱, 속도) / react-query의 useInfiniteQuery 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-cookie": "^4.1.1",
     "react-datepicker": "^4.12.0",
     "react-dom": "^18.2.0",
+    "react-infinite-scroller": "^1.2.6",
     "react-query": "^3.39.3",
     "react-router": "^6.11.2",
     "react-router-dom": "^6.11.2",

--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery, useQueryClient } from 'react-query';
 import { getMainPosts } from 'apis/posts';
 import MainPost from 'components/MainPost';
 import LoadingSpinner from 'components/LoadingSpinner';
@@ -10,6 +10,7 @@ import styles from './main.module.scss';
 import DropDownIcon from '../../assets/svg/toggleDropDown.svg';
 
 function MainPage() {
+  const queryClient = useQueryClient();
   const [sort, setSort] = useState('인기순');
   const observRef = useRef(null); // 옵저버 ref
 
@@ -73,6 +74,7 @@ function MainPage() {
   }, [sort]);
 
   useEffect(() => {
+    queryClient.removeQueries('mainPosts');
     refetch();
   }, [searchQuery]);
 

--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -1,5 +1,5 @@
-import { useContext, useEffect, useRef, useState } from 'react';
-import { useQuery } from 'react-query';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useInfiniteQuery } from 'react-query';
 import { getMainPosts } from 'apis/posts';
 import MainPost from 'components/MainPost';
 import LoadingSpinner from 'components/LoadingSpinner';
@@ -10,23 +10,33 @@ import styles from './main.module.scss';
 import DropDownIcon from '../../assets/svg/toggleDropDown.svg';
 
 function MainPage() {
-  const [posts, setPosts] = useState([]);
   const [sort, setSort] = useState('인기순');
-  const [currPage, setCurrPage] = useState(0);
+  const observRef = useRef(null); // 옵저버 ref
 
   const { searchQuery, isSearched, updateSearchQuery, resetSearchQuery } =
     useContext(SearchQueryContext);
   const { sorting, district, keyword } = searchQuery;
 
-  const { data, isLoading, isError, refetch } = useQuery(
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    refetch,
+  } = useInfiniteQuery(
     'mainPosts',
-    () => {
-      const result = getMainPosts(searchQuery);
-      return result;
+    async ({ pageParam = 0 }) => {
+      const res = await getMainPosts({ ...searchQuery, page: pageParam });
+      return res;
     },
     {
-      onSuccess: postsData => {
-        setPosts(postsData.content);
+      getNextPageParam: (lastPage, allPages) => {
+        // lastPage: 직전에 반환된 리턴값, pages: 지금까지 받아온 전체 페이지
+        const totalPages = lastPage.totalPages || 0;
+        const nextPage = allPages.length;
+        return nextPage < totalPages ? nextPage : undefined;
       },
     },
   );
@@ -40,21 +50,42 @@ function MainPage() {
   const handleChangeSortClick = e => {
     const getSort =
       e.target.innerText === '최신 순' ? '최근 게시물 순' : e.target.innerText;
-    setCurrPage(0);
     setSort(getSort);
   };
+
+  // 옵저버 실행
+  const handleObserver = useCallback(
+    entries => {
+      const target = entries[0];
+      if (target.isIntersecting && hasNextPage && !isFetching) {
+        fetchNextPage();
+      }
+    },
+    [hasNextPage, fetchNextPage, isFetching],
+  );
 
   useEffect(() => {
     updateSearchQuery({
       ...searchQuery,
-      page: currPage,
+      page: 0,
       sorting: sort,
     });
-  }, [currPage, sort]);
+  }, [sort]);
 
   useEffect(() => {
     refetch();
   }, [searchQuery]);
+
+  useEffect(() => {
+    // 옵저버 생성, 연결
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: 0,
+    });
+    if (observRef.current) observer.observe(observRef.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [handleObserver]);
 
   return (
     <div className={styles.wrap}>
@@ -62,7 +93,7 @@ function MainPage() {
         {isSearched ? (
           <h2 className={styles.searchResult}>
             {district || '전체'} <span>{keyword && `'${keyword}'`}</span>{' '}
-            검색결과 {(data && data.totalElements) || 0}건
+            검색결과 {(data && data.pages[0].totalElements) || 0}건
           </h2>
         ) : (
           <h2 className={styles.title}>오늘의 Pick!</h2>
@@ -101,11 +132,19 @@ function MainPage() {
           </div>
         </button>
       </div>
-      {posts.map(post => (
-        <MainPost key={post.id} post={post} />
-      ))}
+      {data &&
+        data.pages.map(page =>
+          page.content.map((post, index) => (
+            <MainPost key={uuid()} post={post} />
+          )),
+        )}
+      {hasNextPage && !isFetching && (
+        <div ref={observRef} style={{ height: '2rem' }}>
+          <LoadingSpinner />
+        </div>
+      )}
       {isLoading && <LoadingSpinner />}
-      {data && posts.length === 0 && (
+      {data && data.pages[0].content.length === 0 && (
         <div className={styles.notFound}>
           <p>검색 결과가 존재하지 않습니다.</p>
           <button type='button' onClick={resetSearchQuery}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8327,7 +8327,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.8, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8495,6 +8495,13 @@ react-fast-compare@^3.0.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
+
+react-infinite-scroller@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"
+  integrity sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
https://github.com/ShareOffice-11/FE/issues/198 [[Refactor] 무한스크롤 - 성능 개선(캐싱, 속도) / react-query의 useInfiniteQuery 도입](https://github.com/ShareOffice-11/FE/commit/229e156d525c3aaf9ce13bba548967ddd9f33af4)


https://github.com/ShareOffice-11/FE/issues/199 [[Fix] 무한 스크롤 - 새로 검색 또는 정렬 시, 이전 스크롤 페이지 넘버가 초기화 되지 않아 0~n페이지 까지…](https://github.com/ShareOffice-11/FE/commit/3f1502755ed53f5066da7ae5e633bb1bfdd5805d) 

…의 데이터 리스트를 모두 불러오는 문제 발생