### PR TITLE
#201 유저피드백 반영 - UI/UX 디자인 관련

### DIFF
--- a/src/apis/auth/kakao.js
+++ b/src/apis/auth/kakao.js
@@ -5,7 +5,8 @@ const authKakaoLogin = async code => {
     const { data } = await instance.get(`/oauth/kakao?code=${code}`);
     return data.message;
   } catch (error) {
-    throw new Error(error);
+    alert(`카카오 로그인 에러 발생 : ${error.response.data.status}`);
+    throw error.response.data;
   }
 };
 

--- a/src/components/common/header/Header.jsx
+++ b/src/components/common/header/Header.jsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import SearchBar from 'components/common/header/SearchBar';
 import { useContext } from 'react';
 import { useMutation } from 'react-query';
@@ -13,9 +13,12 @@ import { SearchQueryContext } from '../../../contexts/SearchQueryContext';
 import { AuthContext } from '../../../contexts/AuthContext';
 import { authLogout } from '../../../apis/auth/login';
 import { removeCookie } from '../../../utils/helpers/cookies';
+import AirBox from '../airBox/AirBox';
 
 function Header() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { pathname } = location;
   const { searchToggleSwitch } = useContext(searchToggleContext);
   const { resetSearchQuery } = useContext(SearchQueryContext);
   const { isLogin, updateLoginStatus } = useContext(AuthContext);
@@ -47,6 +50,7 @@ function Header() {
       >
         <img src={BackArrowIcon} alt='goto-back'></img>
       </button>
+      {!pathname.includes('room') && <AirBox width='2rem' />}
       <Link to='/main' onClick={resetSearchQuery}>
         <h1 className={styles.logo}>
           <img src={LogoIcon} alt='goto-back'></img>
@@ -61,13 +65,15 @@ function Header() {
           <img src={SearchIcon} alt='goto-back'></img>
         </button>
         {isLogin ? (
-          <button
-            type='button'
-            className={styles.login}
-            onClick={handleLogoutClick}
-          >
-            <img src={LogoutIcon} alt='goto-logout' />
-          </button>
+          !pathname.includes('room') && (
+            <button
+              type='button'
+              className={styles.login}
+              onClick={handleLogoutClick}
+            >
+              <img src={LogoutIcon} alt='goto-logout' />
+            </button>
+          )
         ) : (
           <button
             type='button'

--- a/src/components/common/header/header.module.scss
+++ b/src/components/common/header/header.module.scss
@@ -18,11 +18,9 @@
 
   h1.logo {
     width: 7.6875rem;
-    margin-left: 2rem;
   }
 
   .flexCon {
-    width: 5.625rem;
     display: flex;
   }
 

--- a/src/components/common/layout/Layout.jsx
+++ b/src/components/common/layout/Layout.jsx
@@ -7,7 +7,6 @@ import { SearchToggleProvider } from '../../../contexts/SearchToggleContext';
 
 function Layout() {
   const location = useLocation();
-  console.log(location);
   return (
     <SearchToggleProvider>
       <SearchQueryProvider>

--- a/src/components/common/layout/Layout.jsx
+++ b/src/components/common/layout/Layout.jsx
@@ -7,6 +7,7 @@ import { SearchToggleProvider } from '../../../contexts/SearchToggleContext';
 
 function Layout() {
   const location = useLocation();
+  console.log(location);
   return (
     <SearchToggleProvider>
       <SearchQueryProvider>

--- a/src/components/common/layout/layout.module.scss
+++ b/src/components/common/layout/layout.module.scss
@@ -7,7 +7,6 @@
 
   .backgroundWrap {
     @include backgroundWrap;
-    background: url('../../../assets/img/introBg.jpg') 50% / cover no-repeat;
 
     .layoutCon {
       @include layout;

--- a/src/components/common/nav/Nav.jsx
+++ b/src/components/common/nav/Nav.jsx
@@ -1,5 +1,5 @@
-import React, { useContext } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import styles from './nav.module.scss';
 import homeIcon from '../../../assets/svg/home.svg';
 import chattingIcon from '../../../assets/svg/chatting.svg';
@@ -9,8 +9,8 @@ import topIcon from '../../../assets/svg/topIcon.svg';
 import { SearchQueryContext } from '../../../contexts/SearchQueryContext';
 
 function Nav() {
-  const navigate = useNavigate();
   const location = useLocation();
+  const { pathname } = location;
   const { resetSearchQuery } = useContext(SearchQueryContext);
 
   const handleHomeClick = () => {
@@ -30,9 +30,7 @@ function Nav() {
               src={homeIcon}
               alt='home'
               className={
-                location.pathname === '/main'
-                  ? styles.selectedIcon
-                  : styles.icon
+                pathname === '/main' ? styles.selectedIcon : styles.icon
               }
             />
           </li>
@@ -43,7 +41,7 @@ function Nav() {
               src={postIcon}
               alt='posting'
               className={
-                location.pathname.startsWith('/posting')
+                pathname.startsWith('/posting')
                   ? styles.selectedIcon
                   : styles.icon
               }
@@ -56,7 +54,7 @@ function Nav() {
               src={chattingIcon}
               alt='chatting'
               className={
-                location.pathname.startsWith('/chatting')
+                pathname.startsWith('/chatting')
                   ? styles.selectedIcon
                   : styles.icon
               }
@@ -69,10 +67,10 @@ function Nav() {
               src={mypageIcon}
               alt='mypage'
               className={
-                location.pathname === '/mypage' ||
-                location.pathname === '/likedposts' ||
-                location.pathname === '/myposts' ||
-                location.pathname === '/myreservations'
+                pathname === '/mypage' ||
+                pathname === '/likedposts' ||
+                pathname === '/myposts' ||
+                pathname === '/myreservations'
                   ? styles.selectedIcon
                   : styles.icon
               }
@@ -80,7 +78,7 @@ function Nav() {
           </li>
         </Link>
       </ul>
-      {location.pathname === '/main' && (
+      {pathname === '/main' && (
         <button
           type='button'
           className={styles.scrollTop}

--- a/src/components/common/slider/Slider.jsx
+++ b/src/components/common/slider/Slider.jsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-import { useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import uuid from 'react-uuid';
 import styles from './slider.module.scss';
 import arrowLeft from '../../../assets/svg/arrowLeft.svg';
@@ -11,6 +11,7 @@ import LikeFullIcon from '../../../assets/svg/likefull.svg';
 import { AuthContext } from '../../../contexts/AuthContext';
 
 function Slider({ post }) {
+  const navigate = useNavigate();
   const location = useLocation();
   const { pathname } = location;
   const isMain = pathname.includes('main');
@@ -53,11 +54,7 @@ function Slider({ post }) {
   };
 
   return (
-    <div
-      className={styles.sliderCon}
-      onClick={e => e.stopPropagation()}
-      role='presentation'
-    >
+    <div className={styles.sliderCon}>
       <ul
         className={styles.slides}
         style={{
@@ -67,13 +64,25 @@ function Slider({ post }) {
       >
         {images &&
           images.map((image, idx) => (
-            <li key={uuid()} className={styles.slide}>
-              <img src={image} alt={`share-office${idx}`}></img>
+            <li
+              key={uuid()}
+              className={styles.slide}
+              onClick={() => isMain && navigate(`/detail/${post.id}`)}
+              role='presentation'
+            >
+              <img src={image} alt={`share-office${idx}`} />
             </li>
           ))}
       </ul>
       {isMain && !isMyPost && (
-        <button type='button' className={styles.like} onClick={handleLikeClick}>
+        <button
+          type='button'
+          className={styles.like}
+          onClick={e => {
+            e.stopPropagation();
+            handleLikeClick();
+          }}
+        >
           {likeStatus ? (
             <img src={LikeFullIcon} alt='like-full-icon'></img>
           ) : (
@@ -81,11 +90,27 @@ function Slider({ post }) {
           )}
         </button>
       )}
-      <div className={styles.arrowButtons}>
-        <button type='button' onClick={handleClickPrevSlide}>
+      <div
+        className={styles.arrowButtons}
+        onClick={() => isMain && navigate(`/detail${post.id}}`)}
+        role='presentation'
+      >
+        <button
+          type='button'
+          onClick={e => {
+            e.stopPropagation();
+            handleClickPrevSlide();
+          }}
+        >
           <img src={arrowLeft} alt='prev-button' />
         </button>
-        <button type='button' onClick={handleClickNextSlide}>
+        <button
+          type='button'
+          onClick={e => {
+            e.stopPropagation();
+            handleClickNextSlide();
+          }}
+        >
           <img src={arrowRight} alt='next-button' />
         </button>
       </div>
@@ -99,7 +124,10 @@ function Slider({ post }) {
                 className={currentPage === idx ? styles.active : ''}
                 id={idx}
                 aria-label='goto-page'
-                onClick={handleClickSetCurrentPage}
+                onClick={e => {
+                  e.stopPropagation();
+                  handleClickSetCurrentPage(e);
+                }}
               />
             ))}
         </div>

--- a/src/components/common/slider/slider.module.scss
+++ b/src/components/common/slider/slider.module.scss
@@ -28,19 +28,21 @@
   .slides {
     display: flex;
     transition: all 0.3s;
+    height: 12.5rem;
 
     .slide {
       width: 100%;
+      height: 100%;
       position: relative;
       object-fit: cover;
+      transition: none;
 
       img {
         width: 100%;
-        height: auto;
+        height: 100%;
         display: block;
-        position: absolute;
         object-fit: cover;
-        top: 10%;
+        cursor: pointer;
       }
     }
   }
@@ -52,6 +54,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    cursor: pointer;
   }
 
   .sliderButtons {

--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -25,7 +25,6 @@ function LoginPage() {
 
   const mutation = useMutation(authLogin, {
     onSuccess: result => {
-      alert(result.message);
       updateLoginStatus();
       navigate('/main');
       resetForm();
@@ -58,42 +57,48 @@ function LoginPage() {
 
   return (
     <div className={styles.wrap}>
-      <FormLabel>간편 로그인</FormLabel>
-      <button
-        type='button'
-        onClick={() => {
-          window.location.href = `${KAKAO_AUTH_URL}`;
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          handleLoginBtnClick();
         }}
-        className={styles.kakaoButton}
       >
-        <img src={KakaoButton} alt='kakao-button' />
-      </button>
-      <AirBox height='2.25rem' />
-      <FormLabel>이메일 로그인</FormLabel>
-      <Input
-        type='text'
-        name='email'
-        value={email}
-        placeholder='아이디를 입력'
-        onChange={handleFormChange}
-      ></Input>
-      <Input
-        type='password'
-        name='password'
-        value={password}
-        placeholder='비밀번호를 입력'
-        onChange={handleFormChange}
-      ></Input>
-      <button
-        type='submit'
-        className={`${styles.loginButton} ${isActiveLogin && styles.active}`}
-        onClick={handleLoginBtnClick}
-      >
-        로그인
-      </button>
-      <p className={styles.signup}>
-        아직 회원이 아니신가요?<Link to='/signup'>회원가입</Link>
-      </p>
+        <FormLabel>간편 로그인</FormLabel>
+        <button
+          type='button'
+          onClick={() => {
+            window.location.href = `${KAKAO_AUTH_URL}`;
+          }}
+          className={styles.kakaoButton}
+        >
+          <img src={KakaoButton} alt='kakao-button' />
+        </button>
+        <AirBox height='2.25rem' />
+        <FormLabel>이메일 로그인</FormLabel>
+        <Input
+          type='text'
+          name='email'
+          value={email}
+          placeholder='이메일을 입력해 주세요'
+          onChange={handleFormChange}
+        ></Input>
+        <Input
+          type='password'
+          name='password'
+          value={password}
+          placeholder='비밀번호를 입력해 주세요'
+          onChange={handleFormChange}
+        ></Input>
+        <button
+          type='submit'
+          className={`${styles.loginButton} ${isActiveLogin && styles.active}`}
+        >
+          로그인
+        </button>
+        <p className={styles.signup}>
+          아직 회원이 아니신가요?<Link to='/signup'>회원가입</Link>
+        </p>
+      </form>
     </div>
   );
 }

--- a/src/shared/PrivateRoutes.jsx
+++ b/src/shared/PrivateRoutes.jsx
@@ -1,13 +1,9 @@
-import React, { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import { Navigate, Outlet } from 'react-router';
 import { AuthContext } from '../contexts/AuthContext';
 
 function PrivateRoutes() {
-  const { isLogin, updateLoginStatus } = useContext(AuthContext);
-
-  // useEffect(() => {
-  //   updateLoginStatus();
-  // }, []);
+  const { isLogin } = useContext(AuthContext);
 
   return isLogin ? (
     <Outlet />

--- a/src/styles/scss/reset.scss
+++ b/src/styles/scss/reset.scss
@@ -23,7 +23,7 @@ html {
 }
 
 body {
-  background-color: $color-Signature-blue;
+  background: url('../../assets/img/introBg.jpg') 50% / cover no-repeat;
 }
 
 li {


### PR DESCRIPTION
https://github.com/ShareOffice-11/FE/issues/201 [[Design] 유저 피드백 - 앱 백그라운드 이미지 확대 시 짤리는 현상 개선(body의 background-image로 변경)](https://github.com/ShareOffice-11/FE/commit/e12c197d045600affbab0451572c4e92526978d3)


https://github.com/ShareOffice-11/FE/issues/201 [[Design] 유저 피드백 - 채팅 룸에서 로그아웃 버튼 없애기(채팅방 나가기와 혼동됨)](https://github.com/ShareOffice-11/FE/commit/29c45833fbfaa946b596a01360969ae50566af21)


https://github.com/ShareOffice-11/FE/issues/201 [[Desig] 로그인 관련 유저 피드백 개선](https://github.com/ShareOffice-11/FE/commit/755f52d48ab049f11a9c242ad9056f64c17f312c) 
- 로그인 인풋 placeholder '아이디 입력 -> 이메일을 입력' 으로 변경
- 로그인 성공 alert 지우기
- 로그인 폼 엔터로 가능하게 변경
- 소셜 로그인 실패 시 에러 메세지

https://github.com/ShareOffice-11/FE/issues/201 [[Design] 유저 피드백 - 슬라이드 이미지 관련 피드백 반영](https://github.com/ShareOffice-11/FE/commit/0571cce5bb0cfb98a37e4a73028ca630ebe1ae5e) 
- 슬라이드 이미지 크기 때문에 짤리는 현상 -> 슬라이드 높이에 딱 맞게 이미지 조정
- 슬라이드 이미지를 클릭해도 상세페이지로 가도록 수정