### PR TITLE
#201 [Ractor] 유저 피드백 - 카카오 로그인 시 뒤로가면 다시 로그인 요청 및 성공 alert뜸 -> 로그인 되어…

### DIFF
--- a/src/pages/login/LoginPage.jsx
+++ b/src/pages/login/LoginPage.jsx
@@ -13,7 +13,7 @@ import useAuth from '../../hooks/useAuth';
 
 function LoginPage() {
   const navigate = useNavigate();
-  const { updateLoginStatus } = useAuth();
+  const { isLogin, updateLoginStatus } = useAuth();
   const initialState = {
     email: '',
     password: '',
@@ -47,6 +47,15 @@ function LoginPage() {
     mutation.mutate(form);
   };
 
+  const handleKakaoLogin = () => {
+    if (isLogin) {
+      alert('이미 로그인된 회원입니다');
+      navigate('/main');
+    } else {
+      window.location.href = `${KAKAO_AUTH_URL}`;
+    }
+  };
+
   useEffect(() => {
     if (email && password) {
       setIsActiveLogin(true);
@@ -66,9 +75,7 @@ function LoginPage() {
         <FormLabel>간편 로그인</FormLabel>
         <button
           type='button'
-          onClick={() => {
-            window.location.href = `${KAKAO_AUTH_URL}`;
-          }}
+          onClick={handleKakaoLogin}
           className={styles.kakaoButton}
         >
           <img src={KakaoButton} alt='kakao-button' />


### PR DESCRIPTION
https://github.com/ShareOffice-11/FE/issues/201 [[Ractor] 유저 피드백 - 카카오 로그인 시 뒤로가면 다시 로그인 요청 및 성공 alert뜸 -> 로그인 되어…](https://github.com/ShareOffice-11/FE/commit/34a50614da95ecfaba0f93c5acdcccaddc818f19) 

…있을 경우 이미 로그인된 회원이라는 알림과 함께 main으로 이동