### PR TITLE
#224 [Improve] 웹 성능 최적화 - 콘텐츠가 포함된 최대 페인트 이미지 미리 로드

### DIFF
--- a/src/components/common/slider/Slider.jsx
+++ b/src/components/common/slider/Slider.jsx
@@ -53,6 +53,12 @@ function Slider({ post }) {
     }
   };
 
+  const handleNavigate = () => {
+    if (isMain) {
+      navigate(`/detail/${post.id}`);
+    }
+  };
+
   return (
     <div className={styles.sliderCon}>
       <ul
@@ -65,9 +71,9 @@ function Slider({ post }) {
         {images &&
           images.map((image, idx) => (
             <li
-              key={`${image + idx} `}
+              key={uuid()}
               className={styles.slide}
-              onClick={() => isMain && navigate(`/detail/${post.id}`)}
+              onClick={handleNavigate}
               role='presentation'
             >
               <img src={image} alt={`share-office${idx}`} />

--- a/src/components/common/slider/Slider.jsx
+++ b/src/components/common/slider/Slider.jsx
@@ -76,7 +76,12 @@ function Slider({ post }) {
               onClick={handleNavigate}
               role='presentation'
             >
-              <img src={image} alt={`share-office${idx}`} />
+              {console.log('idx', idx)}
+              <img
+                src={image}
+                alt={`share-office${idx}`}
+                loading={idx === 0 ? null : 'lazy'}
+              />
             </li>
           ))}
       </ul>


### PR DESCRIPTION
https://github.com/ShareOffice-11/FE/issues/224 [[Improve] 목록에 <li> 요소와 스크립트 지원 요소(<script> 및 <template>)만 포함되지 않음](https://github.com/ShareOffice-11/FE/commit/7b6b63cf77c3d4169141a02fa177fc440656c901) 
- ul > li 내부에 onClick으로 main으로 이동하는 자바스크립트 로직이 포함되어 있어 따로 분리

https://github.com/ShareOffice-11/FE/issues/224 [[Improve] 웹 성능 최적화 - 콘텐츠가 포함된 최대 페인트 이미지 미리 로드](https://github.com/ShareOffice-11/FE/commit/3896a1408e21e896e93150f12ec13d8167dbbd46) 
- 첫 슬라이드 페이지는 lazy-load 제외하여 미리 로드