### PR TITLE
#224 [Improve] 목록에 <li> 요소와 스크립트 지원 요소(<script> 및 <template>)만 포함되지 않음

### DIFF
--- a/src/components/common/slider/Slider.jsx
+++ b/src/components/common/slider/Slider.jsx
@@ -56,7 +56,7 @@ function Slider({ post }) {
 
   return (
     <div className={styles.sliderCon}>
-      <ul
+      <div
         className={styles.slides}
         style={{
           width: `${slideLength}00%`,
@@ -65,7 +65,7 @@ function Slider({ post }) {
       >
         {images &&
           images.map((image, idx) => (
-            <li
+            <div
               key={uuid()}
               className={styles.slide}
               onClick={() => isMain && navigate(`/detail/${post.id}`)}
@@ -76,9 +76,9 @@ function Slider({ post }) {
                 alt={`share-office${idx}`}
                 loading={idx === 0 ? null : 'lazy'}
               />
-            </li>
+            </div>
           ))}
-      </ul>
+      </div>
       {isMain && !isMyPost && (
         <button
           type='button'


### PR DESCRIPTION
- ul > li 내부에 img가 포함되어 발생하는 경고, 슬라이드 리스트를 div로 변경하여 img가 포함되도 경고가 뜨지 않도록 함