### PR TITLE
#238 [Improve] 로그인 - 보안 강화 / 고도화 작업

### DIFF
--- a/src/apis/instance/instance.js
+++ b/src/apis/instance/instance.js
@@ -13,6 +13,7 @@ const instance = axios.create({
 instance.interceptors.request.use(config => {
   if (config.headers === undefined) return config;
   const accessToken = axios.defaults.headers.common.Access_Token;
+
   if (accessToken) {
     // eslint-disable-next-line no-param-reassign
     config.headers.Access_Token = accessToken;
@@ -47,7 +48,10 @@ instance.interceptors.response.use(
     // 액세스 토큰 만료 시 재발급
     if (errorCode === 'TOKEN_ERROR') {
       const data = await tokenRefresh();
-      if (data) axios.defaults.headers.common.Access_Token = data;
+      if (data) {
+        axios.defaults.headers.common.Access_Token = data;
+        localStorage.setItem('isLoggedIn', true);
+      }
 
       // 다시 이전요청 보내는 로직
       const originalRequests = config;

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -13,13 +13,6 @@ const useAuth = () => {
     setIsLogin(!!isToken);
   };
 
-  // 액세스 토큰 재발급 mutation, 성공 시 로그인 상태 업데이트
-  const authMutation = useMutation(tokenRefresh, {
-    onSuccess: data => {
-      axios.defaults.headers.common.Access_Token = data;
-    },
-  });
-
   const checkingLogin = () => {
     if (isLogin) return true;
     alert('로그인시 이용 가능한 서비스입니다');
@@ -32,14 +25,23 @@ const useAuth = () => {
     alert(`${message} 처리 되었습니다`);
   };
 
+  // 액세스 토큰 재발급 mutation, 성공 시 로그인 상태 업데이트
+  const authMutation = useMutation(tokenRefresh, {
+    onSuccess: data => {
+      axios.defaults.headers.common.Access_Token = data;
+    },
+    onError: error => {
+      console.log('authMutation error:', error);
+      if (error.message !== '리프레쉬 토큰이 만료되어 로그인이 필요합니다.') {
+        logout('서버 에러로 인하여 로그아웃');
+      }
+    },
+  });
+
   // 새로고침시 액세스 토큰 재발급
-  const reloadTokenRefresh = async () => {
+  const reloadTokenRefresh = () => {
     authMutation.mutate();
   };
-
-  useEffect(() => {
-    console.log('isLogin', isLogin);
-  }, [isLogin]);
 
   useEffect(() => {
     const isLoggedIn = localStorage.getItem('isLoggedIn');

--- a/src/shared/PrivateRoutes.jsx
+++ b/src/shared/PrivateRoutes.jsx
@@ -1,10 +1,9 @@
 import { Navigate, Outlet } from 'react-router';
-import useAuth from '../hooks/useAuth';
 
 function PrivateRoutes() {
-  const { isLogin } = useAuth();
+  const isLoggedIn = localStorage.getItem('isLoggedIn');
 
-  return isLogin ? (
+  return isLoggedIn ? (
     <Outlet />
   ) : (
     <>


### PR DESCRIPTION
- 액세스 토큰이 재발급 되기 전에 먼저 로그인이 필요하다는 경고 문구를 띄우는 문제 해결
- PrivateRouter에서 로그인 여부 확인을 localStorage의 isLoggedIn으로 확인 하도록 변경, 새로고침 되어 isLogin이 false일 때는 즉시 액세스 토큰 재발급 요청하여 로그인 세션이 유지되도록